### PR TITLE
Fix "Warning: Path must be a string." error.

### DIFF
--- a/lint-options.json
+++ b/lint-options.json
@@ -17,5 +17,6 @@
     "describe": true,
     "afterEach": true,
     "it": true
-  }
+  },
+  "reporterOutput": ""
 }


### PR DESCRIPTION
Please consider accepting this pull request to fix an apparent test issue.
Tests can be successfully performed without this PR using grunt's "--force" command line argument, but the intention seems to be to have "grunt test" work straight away.

Please also note that I am testing on Windows. It may be that the issue does not occur on other platforms, but hopefully this particular fix will work benignly on them.